### PR TITLE
R4R: change userCLA value to accommodate ledger app

### DIFF
--- a/user_app.go
+++ b/user_app.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	userCLA = 0x55
+	userCLA = 0xBC
 
 	userINSGetVersion                   = 0
 	userINSPublicKeySECP256K1           = 1


### PR DESCRIPTION
The `userCLA` represents the ledger app ID. The ID of `binance-ledger-app` is 0xBC, however the ID of `cosmos-ledger-app` is 0x55. We have to change `userCLA` to accommodate ledger app.