### PR TITLE
R4R: change module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cosmos/ledger-cosmos-go
+module github.com/zondax/ledger-cosmos-go
 
 go 1.12
 


### PR DESCRIPTION
change node and comos-sdk to go mod, it reported module name error:
```
go: github.com/binance-chain/ledger-cosmos-go@v0.9.9-binance.2: parsing go.mod: unexpected module path "github.com/cosmos/ledger-cosmos-go"
```